### PR TITLE
Extract methods and types in tcp_app_lib, Change KeyValueApp proto namespace 

### DIFF
--- a/key_value_store_app/app/key_value_store_app.h
+++ b/key_value_store_app/app/key_value_store_app.h
@@ -36,7 +36,7 @@ public:
         return utils::GetMessageBufferCapacity();
     }
 
-    key_value_store_app::KeyValueStoreAppCommand ParseMessage(char* message_str);
+    KeyValueStoreAppProto::Command ParseMessage(char* message_str);
 
     tcp_util::ACTION_ON_CONNECTION HandleMessage(
             std::shared_ptr<TCPMessage> tcp_message) override;

--- a/key_value_store_app/client/key_value_store_app_client.cpp
+++ b/key_value_store_app/client/key_value_store_app_client.cpp
@@ -7,8 +7,8 @@
 #include "proto/key_value_store_app.pb.h"
 #include "key_value_store_app_client.h"
 
-using key_value_store_app::KeyValueStoreAppCommand;
-using key_value_store_app::KeyValueStoreAppCommandType;
+using KeyValueStoreAppProto::Command;
+using KeyValueStoreAppProto::CommandType;
 
 KeyValueStoreAppClient::KeyValueStoreAppClient(
         std::string name, std::string ipAddress,
@@ -22,39 +22,41 @@ KeyValueStoreAppClient::~KeyValueStoreAppClient() {
 
 std::unique_ptr<Message> KeyValueStoreAppClient::Execute(std::string input_command) {
     tcp_client_->SendMessage(input_command);
-    return std::move(tcp_client_->ReceiveMessage(utils::GetMessageBufferCapacity()));
+    return std::move(tcp_client_->ReceiveMessage(utils::GetMessageBufferCapacity()).result_);
 }
 
 std::string KeyValueStoreAppClient::GetEntry(std::string key) {
-    KeyValueStoreAppCommand command;
-    command.set_type(KeyValueStoreAppCommandType::GetEntry);
+    Command command;
+    command.set_type(CommandType::GetEntry);
     command.set_key(key);
-    if (tcp_client_->SendMessage(command.SerializeAsString())) {
-        auto message = tcp_client_->ReceiveMessage(utils::GetMessageBufferCapacity());
-        if (message) {
-            return message->data_str();
+    auto send_res = tcp_client_->SendMessage(command.SerializeAsString());
+    if (send_res.success_) {
+        auto recv_res = tcp_client_->ReceiveMessage(utils::GetMessageBufferCapacity());
+        if (recv_res.success_) {
+            return recv_res.result_->data_str();
         } else {
-            SPDLOG_ERROR("No message from app.");
+            SPDLOG_ERROR(fmt::format("Receive failed due to error: {}", recv_res.error_.to_string()));
         }
     } else {
-        SPDLOG_ERROR("Failed to send message");
+        SPDLOG_ERROR(fmt::format("Send failed due to error: {}", send_res.error_.to_string()));
     }
     return "";
 }
 std::string KeyValueStoreAppClient::PutEntry(std::string key, std::string value) {
-    KeyValueStoreAppCommand command;
-    command.set_type(KeyValueStoreAppCommandType::PutEntry);
+    Command command;
+    command.set_type(CommandType::PutEntry);
     command.set_key(key);
     command.set_value(value);
-    if (tcp_client_->SendMessage(command.SerializeAsString())) {
-        auto message = tcp_client_->ReceiveMessage(utils::GetMessageBufferCapacity());
-        if (message) {
-            return message->data_str();
+    auto send_res = tcp_client_->SendMessage(command.SerializeAsString());
+    if (send_res.success_) {
+        auto recv_res = tcp_client_->ReceiveMessage(utils::GetMessageBufferCapacity());
+        if (recv_res.success_) {
+            return recv_res.result_->data_str();
         } else {
-            SPDLOG_ERROR("No message from app.");
+            SPDLOG_ERROR(fmt::format("Receive failed due to error: {}", recv_res.error_.to_string()));
         }
     } else {
-        SPDLOG_ERROR("Failed to send message");
+        SPDLOG_ERROR(fmt::format("Send failed due to error: {}", send_res.error_.to_string()));
     }
     return "";
 }

--- a/key_value_store_app/key_value_store_app_test.cpp
+++ b/key_value_store_app/key_value_store_app_test.cpp
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #include "../third_party/spdlog/include/spdlog/spdlog.h"
 
 #include "app/key_value_store_app.h"
@@ -75,7 +75,7 @@ void TestKeyValueStoreAppAndClient() {
     for(int i=0; i<number_of_clients; i++) {
         threads.push_back(std::move(std::thread(client_perform_read_write_cb, i)));
     }
-    for (auto&& t : threads) {
+    for (auto& t : threads) {
         t.join();
     }
     app_setup_info.stop_cb();
@@ -83,6 +83,7 @@ void TestKeyValueStoreAppAndClient() {
 }
 
 int main() {
+    spdlog::set_level(spdlog::level::trace);
     spdlog::set_pattern("[%l] [%n] [%A-%d-%m-%Y] [%H:%M:%S] [%z] [%t] %s:%# %v");
     TestKeyValueStoreAppAndClient();
     return 0;

--- a/key_value_store_app/proto/key_value_store_app.proto
+++ b/key_value_store_app/proto/key_value_store_app.proto
@@ -1,15 +1,15 @@
 syntax = "proto2";
-package key_value_store_app;
+package KeyValueStoreAppProto;
 
-enum KeyValueStoreAppCommandType {
+enum CommandType {
   Unknown = 0;
   GetEntry = 1;
   PutEntry = 2;
   Close = 3;
 }
 
-message KeyValueStoreAppCommand {
-  required KeyValueStoreAppCommandType type = 1;
+message Command {
+  required CommandType type = 1;
   optional string key = 2;
   optional string value = 3;
 }

--- a/tcp_app_lib/tcp_client/tcp_client.cpp
+++ b/tcp_app_lib/tcp_client/tcp_client.cpp
@@ -19,28 +19,11 @@
 TCPClient::TCPClient(std::string dest_ip_address,
                      unsigned int dest_port,
                      std::string name) :
-    dest_ip_address_(dest_ip_address),
-    dest_port_(dest_port),
-    name_(name) {
-    /* Change this to get TCPAddress and TCPSocket for TCPConnection Constructor */
-    struct addrinfo hints;
-    struct addrinfo* res;
-    // first, load up address structs with getaddrinfo():
-    memset(&hints, 0, sizeof hints);
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    getaddrinfo(dest_ip_address_.c_str(), std::to_string(dest_port_).c_str(), &hints, &res);
-    // make a socket:
-    sock_fd_ = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    if (sock_fd_ < 0) {
-        SPDLOG_ERROR(fmt::format("socket failed: {}",  tcp_util::Error(errno).to_string()));
-    }
-    if(connect(sock_fd_, res->ai_addr, res->ai_addrlen) < 0 ) {
-        SPDLOG_ERROR(fmt::format("connect failed: {}",  tcp_util::Error(errno).to_string()));
-    }
-    connection_ = std::make_shared<TCPConnection>(res->ai_addr, sock_fd_);
+                                         dest_ip_address_(dest_ip_address),
+                                         dest_port_(dest_port),
+                                         name_(name) {
+    connection_ = std::make_shared<TCPConnection>(dest_ip_address_, dest_port_);
 }
 
 TCPClient::~TCPClient() {
-    if(sock_fd_ >= 0) close(sock_fd_);
 }

--- a/tcp_app_lib/tcp_client/tcp_client.h
+++ b/tcp_app_lib/tcp_client/tcp_client.h
@@ -23,16 +23,14 @@ public:
         return name_;
     }
 
-    bool SendMessage(std::string message) const {
+    tcp_util::OperationResult<int>
+    SendMessage(std::string message) const {
         return connection_->SendMessage(message);
     }
 
-    std::unique_ptr<Message> ReceiveMessage(size_t buffer_capacity) const {
+    tcp_util::OperationResult<std::unique_ptr<Message>>
+    ReceiveMessage(size_t buffer_capacity) const {
         return std::move(connection_->ReceiveMessage(buffer_capacity));
-    }
-
-    int sock_fd() const {
-        return sock_fd_;
     }
 
 private:
@@ -40,7 +38,6 @@ private:
     unsigned int dest_port_;
     std::string name_;
     std::shared_ptr<TCPConnection> connection_;
-    int sock_fd_ = -1;
 };
 
 

--- a/tcp_app_lib/tcp_client/tcp_client_test.cpp
+++ b/tcp_app_lib/tcp_client/tcp_client_test.cpp
@@ -13,9 +13,12 @@ const unsigned int PORT = 8081;
 int main() {
     spdlog::set_pattern("[%l] [%n] [%A-%d-%m-%Y] [%H:%M:%S] [%z] [%t] %s:%# %v");
     auto client = std::make_shared<TCPClient>("127.0.0.1", PORT, "first");
-    if (client && client->SendMessage("Nice test")) {
-        auto message = client->ReceiveMessage(512);
-        SPDLOG_INFO(message->data_str());
+    if (client) {
+        auto send_res = client->SendMessage("Nice test");
+        if (send_res.success_) {
+            auto recv_res = client->ReceiveMessage(512);
+            SPDLOG_INFO(recv_res.result_->data_str());
+        }
     }
     return 0;
 }

--- a/tcp_app_lib/tcp_server/tcp_server.h
+++ b/tcp_app_lib/tcp_server/tcp_server.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <unistd.h>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "../tcp_utils/tcp_connection.h"
 #include "../tcp_utils/tcp_message.h"
@@ -35,9 +36,11 @@ public:
 protected:
     bool BindAndListen();
     void AcceptConnections();
+    void AcceptMessages();
+
     std::shared_ptr<TCPConnection> AcceptConnection();
-    void PopulateFdSetWithConnectedClients(fd_set& fd_set);
     void AcceptMessage(std::shared_ptr<TCPConnection> client, bool spawn_thread = true);
+    void PopulateSetWithConnectedClients(std::unordered_set<unsigned int>& fd_set);
     std::shared_ptr<TCPMessage> GetMessage(std::shared_ptr<TCPConnection> client);
     void HandleMessage(std::shared_ptr<TCPMessage> message);
 private:
@@ -83,7 +86,6 @@ private:
       handling_clients_map_;
   std::mutex handling_clients_map_lock_;
 
-  fd_set active_clients_fd_set_;
   bool is_on_ = false;
 };
 

--- a/tcp_app_lib/tcp_server_app_client/tcp_server_app_client_test.cpp
+++ b/tcp_app_lib/tcp_server_app_client/tcp_server_app_client_test.cpp
@@ -6,6 +6,7 @@
 
 #include "../../third_party/spdlog/include/spdlog/spdlog.h"
 
+#include "..//tcp_client/tcp_client.h"
 #include "tcp_server_app_client.h"
 
 const unsigned int PORT = 8081;
@@ -13,10 +14,12 @@ const unsigned int PORT = 8081;
 int main() {
     spdlog::set_pattern("[%l] [%n] [%A-%d-%m-%Y] [%H:%M:%S] [%z] [%t] %s:%# %v");
     auto app_client = std::make_shared<TCPServerAppClient>("127.0.0.1", PORT, "client-1");
-    if (app_client->tcp_client()->SendMessage("hi from app client")) {
-        auto message = app_client->tcp_client()->ReceiveMessage(512);
-        PRINT_THREAD_ID
-        SPDLOG_INFO(fmt::format("Received message: {}", message->data()));
+    auto send_res = app_client->tcp_client()->SendMessage("hi from app client");
+    if (send_res.success_) {
+        auto recv_res = app_client->tcp_client()->ReceiveMessage(512);
+        if(recv_res.success_) {
+            SPDLOG_INFO(fmt::format("Received message: {}", recv_res.result_->data()));
+        }
     }
     return 0;
 }

--- a/tcp_app_lib/tcp_utils/message.cpp
+++ b/tcp_app_lib/tcp_utils/message.cpp
@@ -2,7 +2,7 @@
 // Created by Shubham Sawant on 16/12/21.
 //
 
-#include <iostream>
+#include <cstring>
 #include <string>
 
 #include "message.h"
@@ -17,7 +17,7 @@ Message::Message(const std::string message_data) {
 }
 
 Message::~Message() {
-    delete data_;
+     free(data_);
 }
 
 char* Message::data() const {
@@ -69,9 +69,9 @@ Message::Message(Message&& message) {
 }
 
 void Message::reset_buffer(size_t buffer_capacity) {
-    if(data_) delete data_;
+    free(data_);
     length_ = 0;
     buffer_capacity_ = buffer_capacity;
-    data_ = new char[buffer_capacity_];
+    data_ = (char*)malloc(buffer_capacity_*sizeof(char));
     memset(data_,0,buffer_capacity_*sizeof(char));
 }

--- a/tcp_app_lib/tcp_utils/tcp_connection.cpp
+++ b/tcp_app_lib/tcp_utils/tcp_connection.cpp
@@ -17,12 +17,52 @@ TCPConnection::TCPConnection() {
 }
 
 
-TCPConnection::TCPConnection(struct sockaddr* address,
-                             unsigned int socket_fd)
-    : address_(address),
-      socket_fd_(socket_fd) {
-    address_length_ = (socklen_t*) malloc(sizeof(socklen_t));
-    *address_length_ = sizeof (address_);
+TCPConnection::TCPConnection(std::string dest_ip_address,
+                             unsigned int dest_port) :
+    peer_ip_address_(dest_ip_address),
+    peer_port_(dest_port){
+    ConnectToPeer(peer_ip_address_, peer_port_);
+}
+
+bool TCPConnection::ConnectToPeer(std::string dest_ip_address,
+                                  unsigned int dest_port) {
+    // TODO(moghya): move this to tcp_utils
+    struct addrinfo hints;
+    struct addrinfo *result;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    int rc = getaddrinfo(dest_ip_address.c_str(), std::to_string(dest_port).c_str(), &hints, &result);
+    if (rc != 0) {
+        SPDLOG_ERROR(fmt::format("getaddrinfo failed: {}",  tcp_util::Error(errno).to_string()));
+    }
+    struct addrinfo* rp;
+    for (rp = result; rp != NULL; rp = rp->ai_next) {
+        socket_fd_ = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (socket_fd_ < 0) {
+            SPDLOG_ERROR(fmt::format("socket failed: {}, Continuing...",  tcp_util::Error(errno).to_string()));
+            continue;
+        }
+        if (connect(socket_fd_, rp->ai_addr, rp->ai_addrlen) < 0) {
+            SPDLOG_ERROR(fmt::format("connect failed: {}",  tcp_util::Error(errno).to_string()));
+            close(socket_fd_);
+            continue;
+        } else {
+            address_ = (struct sockaddr*) malloc(sizeof(struct sockaddr_in));
+            memset(address_, 0, sizeof(struct sockaddr));
+            *address_ = *(rp->ai_addr);
+            address_length_ = (socklen_t*) malloc(sizeof(socklen_t));
+            *address_length_ = sizeof (address_);
+            initiator_ = true;
+            SPDLOG_INFO("connect succeeded");
+            break;
+        }
+    }
+    freeaddrinfo(result);
+    if (address_ == nullptr) {
+        SPDLOG_ERROR("Could not create connection.");
+        return false;
+    }
+    return true;
 }
 
 TCPConnection::~TCPConnection() {
@@ -43,25 +83,32 @@ size_t TCPConnection::address_length() const {
     return sizeof(address_);
 }
 
-void TCPConnection::set_socket_fd(unsigned int sokect_fd) {
-    socket_fd_ = sokect_fd;
+void TCPConnection::set_socket_fd(int socket_fd) {
+    socket_fd_ = socket_fd;
 }
 
-unsigned int TCPConnection::socket_fd() const {
+int TCPConnection::socket_fd() const {
     return socket_fd_;
 }
 
-std::unique_ptr<Message> TCPConnection::ReceiveMessage(size_t buffer_capacity) {
-    auto message = std::move(tcp_util::receive_stream_message(
-                            this->socket_fd(),buffer_capacity));
-    if (message == nullptr) return nullptr;
-    message->put_data(message->length(), 0);
-    return std::move(message);
+tcp_util::OperationResult<std::unique_ptr<Message>>
+TCPConnection::ReceiveMessage(size_t buffer_capacity) const {
+    auto res = tcp_util::receive_stream_message(
+            this->socket_fd(), buffer_capacity);
+//    if (res.success_) {
+//        res.result_->put_data(res.result_->length(), 0);
+//    }
+    return res;
 }
 
-bool TCPConnection::SendMessage(std::string message_data) const {
+tcp_util::OperationResult<int>
+TCPConnection::SendMessage(std::string message_data) const {
     auto message = std::make_unique<Message>(message_data);
-    size_t sent_size = tcp_util::send_stream_message(
-                this->socket_fd(), std::move(message));
-    return sent_size == message_data.size();
+    auto res  = tcp_util::send_stream_message(
+            this->socket_fd(), std::move(message));
+    return res;
+}
+
+bool TCPConnection::initiator() const {
+    return initiator_;
 }

--- a/tcp_app_lib/tcp_utils/tcp_connection.h
+++ b/tcp_app_lib/tcp_utils/tcp_connection.h
@@ -7,9 +7,11 @@
 
 #include <netdb.h>
 #include <netinet/in.h>
+#include <string>
 #include <sys/socket.h>
 
 #include "message.h"
+#include "tcp_utils.h"
 
 enum TCPConnectionState {
     CREATED,
@@ -25,22 +27,35 @@ enum TCPConnectionState {
 class TCPConnection {
 public:
     TCPConnection();
-    TCPConnection(struct sockaddr* address, unsigned int socket_fd);
+    TCPConnection(std::string peer_ip_address,
+                  unsigned int peer_port);
     ~TCPConnection();
     struct sockaddr* address() const;
     socklen_t* address_length_ptr() const;
     size_t address_length() const;
-    void set_socket_fd(unsigned int sokect_fd);
-    unsigned int socket_fd() const;
+    void set_socket_fd(int socket_fd);
+    int socket_fd() const;
+    bool initiator() const;
     /*
      * Following methods are wrapper around recv and send methods.
      * */
-    std::unique_ptr<Message> ReceiveMessage(size_t buffer_capacity);
-    bool SendMessage(std::string message_data) const;
+    tcp_util::OperationResult<std::unique_ptr<Message>>
+    ReceiveMessage(size_t buffer_capacity) const;
+
+    tcp_util::OperationResult<int>
+    SendMessage(std::string message_data) const;
+
 private:
-    struct sockaddr* address_;
-    socklen_t* address_length_;
+    bool ConnectToPeer(std::string ip_address, unsigned int port);
+
+private:
+    struct sockaddr* address_ = nullptr;
+    socklen_t* address_length_ = nullptr;
     int socket_fd_ = -1;
+    bool initiator_ = false;
+
+    std::string peer_ip_address_;
+    unsigned int peer_port_;
 };
 
 

--- a/tcp_app_lib/test.cpp
+++ b/tcp_app_lib/test.cpp
@@ -59,7 +59,7 @@ void TestTCPClientAndTCPServer() {
             auto recv_res = client.ReceiveMessage(512);
             if (recv_res.success_) {
                 test_pass_count++;
-                SPDLOG_INFO(fmt::format("Received message: {}", rec_res.result_->data()));
+                SPDLOG_INFO(fmt::format("Received message: {}", recv_res.result_->data()));
             } else {
                 SPDLOG_ERROR("Could not receive message.");
                 test_fail_count++;


### PR DESCRIPTION
- Fix bugs and improve TCPAppLib
- Add ErrorType in tcp_utils
- User Error in log messages
- Move connect call from TCPClient to TCPConnection
- Fix socket type to be int
- Add OperationResult type as wrapper for tcp utils operation
- Extract get_readable_fds_using_select, add message processor thread to TCPServer
- Update KeyValueStoreApp to use OperationResult type
